### PR TITLE
Add instructions for cross compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MicroPython specific ignores
+*.mpy
+
 # custom, package specific ignores
 .DS_Store
 .DS_Store?

--- a/README.md
+++ b/README.md
@@ -68,11 +68,42 @@ Execute the folling commands inside the rshell to copy the files to the board.
 
 ```bash
 # inside the rshell
-cp main.py /pyboard
+cp blink.py /pyboard
 cp boot.py /pyboard
+cp main.py /pyboard
+```
+
+### Precompile module
+
+The MicroPython board has to convert the provided `*.py` files during runtime
+into a file that can be executed by the controller. To speed things up and to
+reduce the CPU load these files can be cross-compiled on a computer and then
+transfered to the MicroPython board.
+
+See [MicroPython cross-compile README][ref-upy-cross-compile-readme]
+
+> This will create a file foo.mpy which can then be copied to a place
+> accessible by the target MicroPython runtime (eg onto a pyboard's
+> filesystem), and then imported like any other Python module using import foo.
+
+In this example the [`blink.py`][blink.py] file gets cross-compiled
+
+```bash
+python -m mpy_cross blink.py
+rshell -p /dev/tty.wchusbserial1410
+```
+
+Execute the folling commands inside the rshell to copy the cross-compiled
+file to the board and remove the prevoiusly copied, non cross-compiled file.
+
+```bash
+# inside the rshell
+cp blink.mpy /pyboard
+rm /pyboard/blink.py
 ```
 
 <!-- Links -->
 [ref-esptool]: https://github.com/espressif/esptool
 [ref-remote-upy-shell]: https://github.com/dhylands/rshell
 [ref-upy-firmware-download]: https://micropython.org/download/
+[ref-upy-cross-compile-readme]: https://github.com/micropython/micropython/tree/master/mpy-cross

--- a/blink.py
+++ b/blink.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""
+Blink helper module
+
+Toggle pin on and off
+"""
+
+import time
+
+
+def flash_led(pin, amount, on_time=0.5, off_time=0.5):
+    """
+    Flash onboard LED at given pin
+
+    :param      pin:       The pin connected to the LED
+    :type       pin:       int
+    :param      amount:    The amount the LED flashes
+    :type       amount:    int
+    :param      on_time:   On time of the LED
+    :type       on_time:   float
+    :param      off_time:  Off time of the LED
+    :type       off_time:  float
+    """
+    for x in range(1, amount + 1):
+        pin.value(1)
+        time.sleep(on_time)
+        pin.value(0)
+        time.sleep(off_time)

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+## [x.y.z] - yyyy-mm-dd
+### Added
+### Changed
+### Removed
+### Fixed
+-->
+
+<!-- ## [Unreleased] -->
+
+## Released
+## [0.3.0] - 2022-05-06
+### Added
+- This changelog file
+- `mpy_cross` python package added to [`requirements.txt`](requirements.txt)
+
+### Changed
+- Instructions to cross-compile modules in [`README`](README.md), see [#4][ref-issue-4]
+- `flash_led` function extracted from [`main`](main.py) into
+  [`blink`](blink.py) script
+- Import `flash_led` function in [`main`](main.py) from [`blink`](blink.py)
+- Ignore `*.mpy` cross-compiled files
+
+## [0.2.0] - 2022-04-24
+### Added
+- [`.gitignore`](.gitignore) file
+- [`requirements.txt`](requirements.txt) file
+- Doc string for [`boot`](boot.py) and [`main`](main.py), see [#2][ref-issue-2]
+
+### Changed
+- Replace `ampy` in [`README`](README.md) with `rshell`, see [#1][ref-issue-1]
+
+## [0.1.0] - 2021-07-03
+### Added
+- Micropython [`boot`](boot.py) and [`main`](main.py) files
+- [`README`](README.md) file
+
+<!-- Links -->
+[Unreleased]: https://github.com/brainelectronics/Micropython-Blink/compare/0.3.0...develop
+
+[0.3.0]: https://github.com/brainelectronics/Micropython-Blink/tree/0.3.0
+[0.2.0]: https://github.com/brainelectronics/Micropython-Blink/tree/0.2.0
+[0.1.0]: https://github.com/brainelectronics/Micropython-Blink/tree/0.1.0
+
+[ref-issue-4]: https://github.com/brainelectronics/Micropython-Blink/issues/4
+[ref-issue-2]: https://github.com/brainelectronics/Micropython-Blink/issues/2
+[ref-issue-1]: https://github.com/brainelectronics/Micropython-Blink/issues/1

--- a/main.py
+++ b/main.py
@@ -7,28 +7,13 @@ Main script
 Do your stuff here, similar to the loop() function on Arduino
 """
 
-import time
-
-
-def flash_led(pin, amount):
-    """
-    Flash onboard LED
-
-    :param      pin:     The pin connected to the LED
-    :type       pin:     int
-    :param      amount:  The amount the LED flashes
-    :type       amount:  int
-    """
-    for x in range(1, amount + 1):
-        pin.value(1)
-        time.sleep(0.05)
-        pin.value(0)
-        time.sleep(0.05)
+from blink import flash_led
 
 
 def loop():
     # loop forever
     while True:
+        # flash LED 3 times, then sleep for 3 seconds
         flash_led(led_pin, 3)
         time.sleep(3)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 esptool
 rshell>=0.0.30,<1.0.0
+mpy_cross


### PR DESCRIPTION
### Added
- This changelog file
- `mpy_cross` python package added to [`requirements.txt`](requirements.txt)

### Changed
- Instructions to cross-compile modules in [`README`](README.md), see #4 
- `flash_led` function extracted from [`main`](main.py) into [`blink`](blink.py) script
- Import `flash_led` function in [`main`](main.py) from [`blink`](blink.py)
- Ignore `*.mpy` cross-compiled files
